### PR TITLE
Location labels in .connect()

### DIFF
--- a/src/pop2net/actor.py
+++ b/src/pop2net/actor.py
@@ -143,9 +143,9 @@ class Actor:
         return self.env.get_weight(actor=self, location=location)
 
     def connect(
-        self, 
-        actor: Actor, 
-        location_cls: type | None = None, 
+        self,
+        actor: Actor,
+        location_cls: type | None = None,
         location_label: str | None = None,
         weight: float | None = None,
     ):
@@ -161,8 +161,8 @@ class Actor:
                 Defaults to None.
         """
         self.env.connect_actors(
-            actors=[self, actor], 
-            location_cls=location_cls, 
+            actors=[self, actor],
+            location_cls=location_cls,
             location_label=location_label,
             weight=weight,
         )

--- a/src/pop2net/actor.py
+++ b/src/pop2net/actor.py
@@ -15,12 +15,15 @@ class Actor:
     Actors' behavior can be implemented in classes that inherit from this.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, model=None, *args, **kwargs) -> None:
         """Actor Constructor."""
         self.env = None
         self.id_p2n = None
         self.model = None
         self.type = type(self).__name__
+
+        if model is not None:
+            kwargs["model"] = model
 
         super().__init__(*args, **kwargs)
 

--- a/src/pop2net/actor.py
+++ b/src/pop2net/actor.py
@@ -10,6 +10,7 @@ if typing.TYPE_CHECKING:
 
 import inspect
 
+
 class Actor:
     """This is a Base class to represent actors in the simulation.
 

--- a/src/pop2net/actor.py
+++ b/src/pop2net/actor.py
@@ -142,18 +142,30 @@ class Actor:
         """
         return self.env.get_weight(actor=self, location=location)
 
-    def connect(self, actor: Actor, location_cls: _location = None, weight: float | None = None):
+    def connect(
+        self, 
+        actor: Actor, 
+        location_cls: type | None = None, 
+        location_label: str | None = None,
+        weight: float | None = None,
+    ):
         """Connects this actor with a given other actor via an instance of a given location class.
         If location_cls is None, the default pop2net.Location class is used to create a new location
         instance. If weight is None, it will be set to 1.
 
         Args:
             actor (p2n.Actor): An actor to connect with.
-            location_cls (type): The location class that is used to create a location instance.
+            location_cls (type | None): The location class that is used to create a location instance.
+            location_label (str | None): If provided, this label is attached to the location and overwrites any existing location labels.
             weight(float | None): The edge weight between the actors and the location.
                 Defaults to None.
         """
-        self.env.connect_actors(actors=[self, actor], location_cls=location_cls, weight=weight)
+        self.env.connect_actors(
+            actors=[self, actor], 
+            location_cls=location_cls, 
+            location_label=location_label,
+            weight=weight,
+        )
 
     def disconnect(
         self,

--- a/src/pop2net/actor.py
+++ b/src/pop2net/actor.py
@@ -8,6 +8,7 @@ import warnings
 if typing.TYPE_CHECKING:
     from . import location as _location
 
+import inspect
 
 class Actor:
     """This is a Base class to represent actors in the simulation.
@@ -22,10 +23,13 @@ class Actor:
         self.model = None
         self.type = type(self).__name__
 
-        if model is not None:
+        super_init = super().__init__
+        sig = inspect.signature(super_init)
+
+        if "model" in sig.parameters:
             kwargs["model"] = model
 
-        super().__init__(*args, **kwargs)
+        super_init(*args, **kwargs)
 
     def neighbors(self, location_labels: list[str] | None = None) -> list:
         """Return all neighbors of an actor.

--- a/src/pop2net/creator.py
+++ b/src/pop2net/creator.py
@@ -190,13 +190,7 @@ class Creator:
             actors = []
             for _, row in df.iterrows():
                 if actor_class_dict is None:
-                    if self.env.framework is None:
-                        actor = actor_class()
-                        actor.model = (
-                            self.model
-                        )  # if no model was passed to the env, this is just None
-                    else:
-                        actor = actor_class(model=self.model)
+                    actor = actor_class(model=self.model)
                 else:
                     actor = actor_class_dict[row[actor_class_attr]](model=self.model)
 
@@ -1053,3 +1047,5 @@ class Creator:
             df = df.loc[:, columns]
 
         return df
+    
+    

--- a/src/pop2net/creator.py
+++ b/src/pop2net/creator.py
@@ -1047,5 +1047,3 @@ class Creator:
             df = df.loc[:, columns]
 
         return df
-    
-    

--- a/src/pop2net/environment.py
+++ b/src/pop2net/environment.py
@@ -415,12 +415,19 @@ class Environment:
         """
         return self.g[actor.id_p2n][location.id_p2n]["weight"]
 
-    def connect_actors(self, actors: list, location_cls: type, weight: float | None = None):
+    def connect_actors(
+        self, 
+        actors: list, 
+        location_cls: type | None = None, 
+        location_label: str = None, 
+        weight: float | None = None,
+    ):
         """Connects multiple actors via an instance of a given location class.
 
         Args:
             actors (list): A list of actors.
-            location_cls (type): The location class that is used to create a location instance.
+            location_cls (type | None): The location class that is used to create a location instance.
+            location_label (str | None): If provided, this label is attached to the location and overwrites any existing location labels.
             weight (float | None): The edge weight between the actors and the location.
                 Defaults to None.
         """
@@ -438,6 +445,9 @@ class Environment:
             location = location_cls()
         else:
             location = location_cls(model=self.model)
+
+        if location_label is not None:
+            location.label = location_label
 
         self.add_location(location=location)
         location.add_actors(actors=actors, weight=weight)

--- a/src/pop2net/environment.py
+++ b/src/pop2net/environment.py
@@ -416,10 +416,10 @@ class Environment:
         return self.g[actor.id_p2n][location.id_p2n]["weight"]
 
     def connect_actors(
-        self, 
-        actors: list, 
-        location_cls: type | None = None, 
-        location_label: str = None, 
+        self,
+        actors: list,
+        location_cls: type | None = None,
+        location_label: str = None,
         weight: float | None = None,
     ):
         """Connects multiple actors via an instance of a given location class.

--- a/src/pop2net/environment.py
+++ b/src/pop2net/environment.py
@@ -434,8 +434,9 @@ class Environment:
         if location_cls is None:
             if self.framework is None:
                 location_cls = p2n.Location
-                    
+
             else:
+
                 class Location(p2n.Location, self._framework.Agent):
                     pass
 

--- a/src/pop2net/environment.py
+++ b/src/pop2net/environment.py
@@ -434,17 +434,14 @@ class Environment:
         if location_cls is None:
             if self.framework is None:
                 location_cls = p2n.Location
+                    
             else:
-
                 class Location(p2n.Location, self._framework.Agent):
                     pass
 
                 location_cls = Location
 
-        if self.model is None:
-            location = location_cls()
-        else:
-            location = location_cls(model=self.model)
+        location = location_cls(model=self.model)
 
         if location_label is not None:
             location.label = location_label

--- a/src/pop2net/location.py
+++ b/src/pop2net/location.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from . import actor as _actor
 
+import inspect
+
 
 class Location:
     """Base class for location objects."""
@@ -18,10 +20,13 @@ class Location:
         self.model = None
         self.type = type(self).__name__
 
-        if model is not None:
+        super_init = super().__init__
+        sig = inspect.signature(super_init)
+
+        if "model" in sig.parameters:
             kwargs["model"] = model
 
-        super().__init__(*args, **kwargs)
+        super_init(*args, **kwargs)
 
     def setup(self):
         pass

--- a/src/pop2net/location.py
+++ b/src/pop2net/location.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from . import actor as _actor
-
 import inspect
+
+from . import actor as _actor
 
 
 class Location:

--- a/src/pop2net/location.py
+++ b/src/pop2net/location.py
@@ -10,13 +10,17 @@ class Location:
 
     label: str | None = None
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, model=None, *args, **kwargs) -> None:
         """Location constructor."""
         self.label = self.__class__.__name__ if self.label is None else self.label
         self.env = None
         self.id_p2n = None
         self.model = None
         self.type = type(self).__name__
+
+        if model is not None:
+            kwargs["model"] = model
+
         super().__init__(*args, **kwargs)
 
     def setup(self):

--- a/tests/test_agent/test_actor_connect_and_disconnect.py
+++ b/tests/test_agent/test_actor_connect_and_disconnect.py
@@ -190,6 +190,7 @@ def test_location_label_without_class():
     assert len(actor1.shared_locations(actor=actor2)) == 1
     assert len(actor1.shared_locations(actor=actor2, location_labels=["Library"])) == 1
 
+
 def test_location_label_with_class():
     env = p2n.Environment()
     actor1 = p2n.Actor()

--- a/tests/test_agent/test_actor_connect_and_disconnect.py
+++ b/tests/test_agent/test_actor_connect_and_disconnect.py
@@ -173,3 +173,37 @@ def test_actor_disconnect_2():
     assert actor2 in env.locations[0].actors
 
     assert actor3 not in env.locations[0].actors
+
+
+def test_location_label_without_class():
+    env = p2n.Environment()
+    actor1 = p2n.Actor()
+    actor2 = p2n.Actor()
+    env.add_actors([actor1, actor2])
+
+    actor1.connect(
+        actor=actor2,
+        location_cls=None,
+        location_label="Library",
+    )
+
+    assert len(actor1.shared_locations(actor=actor2)) == 1
+    assert len(actor1.shared_locations(actor=actor2, location_labels=["Library"])) == 1
+
+def test_location_label_with_class():
+    env = p2n.Environment()
+    actor1 = p2n.Actor()
+    actor2 = p2n.Actor()
+    env.add_actors([actor1, actor2])
+
+    class Home(p2n.Location):
+        pass
+
+    actor1.connect(
+        actor=actor2,
+        location_cls=Home,
+        location_label="Library",
+    )
+
+    assert len(actor1.shared_locations(actor=actor2)) == 1
+    assert len(actor1.shared_locations(actor=actor2, location_labels=["Library"])) == 1

--- a/tests/test_agent/test_actor_connect_and_disconnect.py
+++ b/tests/test_agent/test_actor_connect_and_disconnect.py
@@ -208,3 +208,89 @@ def test_location_label_with_class():
 
     assert len(actor1.shared_locations(actor=actor2)) == 1
     assert len(actor1.shared_locations(actor=actor2, location_labels=["Library"])) == 1
+
+
+def test_location_cls_is_None_and_model_is_None():
+    env = p2n.Environment()
+    actor1 = p2n.Actor()
+    actor2 = p2n.Actor()
+    env.add_actors([actor1, actor2])
+
+    actor1.connect(
+        actor=actor2,
+        location_cls=None,
+        weight=2,
+    )
+
+    assert len(actor1.shared_locations(actor=actor2)) == 1
+    assert actor1.get_actor_weight(actor2) == 2
+
+
+def test_location_cls_is_None_and_model_is_not_None():
+    class Model:
+        pass
+
+    model = Model()
+    env = p2n.Environment(model=model)
+    actor1 = p2n.Actor()
+    actor2 = p2n.Actor()
+    env.add_actors([actor1, actor2])
+
+    actor1.connect(
+        actor=actor2,
+        location_cls=None,
+        weight=2,
+    )
+
+    assert len(actor1.shared_locations(actor=actor2)) == 1
+    assert actor1.get_actor_weight(actor2) == 2
+
+def test_location_cls_is_not_None_and_model_is_not_None():
+    class Model:
+        pass
+
+    class Location(p2n.Location):
+        pass
+
+    model = Model()
+    env = p2n.Environment(model=model)
+    actor1 = p2n.Actor()
+    actor2 = p2n.Actor()
+    env.add_actors([actor1, actor2])
+
+    actor1.connect(
+        actor=actor2,
+        location_cls=Location,
+        weight=2,
+    )
+
+    assert len(actor1.shared_locations(actor=actor2)) == 1
+    assert actor1.get_actor_weight(actor2) == 2
+
+
+def test_framework_is_not_None():
+    import mesa
+
+    class Model(mesa.Model):
+        pass
+
+    class Location(p2n.Location, mesa.Agent):
+        pass
+
+    class Agent(p2n.Actor, mesa.Agent):
+        pass
+
+    model = Model()
+    env = p2n.Environment(model=model, framework="mesa")
+    actor1 = Agent(model=model)
+    actor2 = Agent(model=model)
+    env.add_actors([actor1, actor2])
+
+    actor1.connect(
+        actor=actor2,
+        location_cls=Location,
+        weight=2,
+    )
+
+    assert len(actor1.shared_locations(actor=actor2)) == 1
+    assert actor1.get_actor_weight(actor2) == 2

--- a/tests/test_agent/test_actor_connect_and_disconnect.py
+++ b/tests/test_agent/test_actor_connect_and_disconnect.py
@@ -245,6 +245,7 @@ def test_location_cls_is_None_and_model_is_not_None():
     assert len(actor1.shared_locations(actor=actor2)) == 1
     assert actor1.get_actor_weight(actor2) == 2
 
+
 def test_location_cls_is_not_None_and_model_is_not_None():
     class Model:
         pass

--- a/tests/test_creator/test_create_agents.py
+++ b/tests/test_creator/test_create_agents.py
@@ -1,5 +1,6 @@
 import pop2net as p2n
 
+
 def test_simple():
     env = p2n.Environment()
     creator = p2n.Creator(env=env)
@@ -7,6 +8,7 @@ def test_simple():
     creator.create_actors(n=77)
 
     assert len(env.actors) == 77
+
 
 def test_given_actor_class_without_model_in_constructor():
     class TestActor(p2n.Actor):
@@ -19,6 +21,7 @@ def test_given_actor_class_without_model_in_constructor():
 
     assert len(env.actors) == 77
 
+
 def test_given_actor_class_with_model_in_constructor():
     class TestActor(p2n.Actor):
         def __init__(self, model):
@@ -29,7 +32,9 @@ def test_given_actor_class_with_model_in_constructor():
         pass
 
     model = Model()
-    env = p2n.Environment(model=model) # TODO: If the given actor class needs a model, the env also needs a model. Is that a good design?
+    env = p2n.Environment(
+        model=model
+    )  # TODO: If the given actor class needs a model, the env also needs a model. Is that a good design?
     creator = p2n.Creator(env=env)
 
     creator.create_actors(n=77, actor_class=TestActor)

--- a/tests/test_creator/test_create_agents.py
+++ b/tests/test_creator/test_create_agents.py
@@ -1,0 +1,37 @@
+import pop2net as p2n
+
+def test_simple():
+    env = p2n.Environment()
+    creator = p2n.Creator(env=env)
+
+    creator.create_actors(n=77)
+
+    assert len(env.actors) == 77
+
+def test_given_actor_class_without_model_in_constructor():
+    class TestActor(p2n.Actor):
+        pass
+
+    env = p2n.Environment()
+    creator = p2n.Creator(env=env)
+
+    creator.create_actors(n=77, actor_class=TestActor)
+
+    assert len(env.actors) == 77
+
+def test_given_actor_class_with_model_in_constructor():
+    class TestActor(p2n.Actor):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+
+    class Model:
+        pass
+
+    model = Model()
+    env = p2n.Environment(model=model) # TODO: If the given actor class needs a model, the env also needs a model. Is that a good design?
+    creator = p2n.Creator(env=env)
+
+    creator.create_actors(n=77, actor_class=TestActor)
+
+    assert len(env.actors) == 77

--- a/tests/test_environment/test_env_connect_and_disconnect.py
+++ b/tests/test_environment/test_env_connect_and_disconnect.py
@@ -1,7 +1,7 @@
 import pop2net as p2n
 
 
-def test_model_connect_actors_and_disconnect_actors_1():
+def test_1():
     """A test without specifying location types and without removing locations from env."""
 
     env = p2n.Environment()
@@ -55,7 +55,7 @@ def test_model_connect_actors_and_disconnect_actors_1():
     assert len(actor3.locations) == 0
 
 
-def test_model_connect_actors_and_disconnect_actors_2():
+def test_2():
     """A test without removing locations from env."""
 
     env = p2n.Environment()
@@ -130,7 +130,7 @@ def test_model_connect_actors_and_disconnect_actors_2():
     assert len(actor3.locations) == 1
 
 
-def test_model_connect_actors_and_disconnect_actors_3():
+def test_3():
     env = p2n.Environment()
     actor1 = p2n.Actor()
     actor2 = p2n.Actor()
@@ -178,7 +178,7 @@ def test_model_connect_actors_and_disconnect_actors_3():
     assert len(actor3.locations) == 0
 
 
-def test_model_connect_actors_and_disconnect_actors_4():
+def test_4():
     env = p2n.Environment()
     actor1 = p2n.Actor()
     actor2 = p2n.Actor()
@@ -213,7 +213,7 @@ def test_model_connect_actors_and_disconnect_actors_4():
     assert len(actor3.locations) == 0
 
 
-def test_model_connect_actors_and_disconnect_actors_5():
+def test_5():
     """Test actor.shared_locations()"""
     env = p2n.Environment()
     actor1 = p2n.Actor()
@@ -253,3 +253,37 @@ def test_model_connect_actors_and_disconnect_actors_5():
     assert len(actor1.shared_locations(actor=actor2)) == 0
     assert len(actor1.shared_locations(actor=actor2, location_labels=["Home"])) == 0
     assert len(actor1.shared_locations(actor=actor2, location_labels=["School"])) == 0
+
+
+def test_location_label_without_class():
+    env = p2n.Environment()
+    actor1 = p2n.Actor()
+    actor2 = p2n.Actor()
+    env.add_actors([actor1, actor2])
+
+    env.connect_actors(
+        actors=[actor1, actor2],
+        location_cls=None,
+        location_label="Library",
+    )
+
+    assert len(actor1.shared_locations(actor=actor2)) == 1
+    assert len(actor1.shared_locations(actor=actor2, location_labels=["Library"])) == 1
+
+def test_location_label_with_class():
+    env = p2n.Environment()
+    actor1 = p2n.Actor()
+    actor2 = p2n.Actor()
+    env.add_actors([actor1, actor2])
+
+    class Home(p2n.Location):
+        pass
+
+    env.connect_actors(
+        actors=[actor1, actor2],
+        location_cls=Home,
+        location_label="Library",
+    )
+
+    assert len(actor1.shared_locations(actor=actor2)) == 1
+    assert len(actor1.shared_locations(actor=actor2, location_labels=["Library"])) == 1

--- a/tests/test_environment/test_env_connect_and_disconnect.py
+++ b/tests/test_environment/test_env_connect_and_disconnect.py
@@ -270,6 +270,7 @@ def test_location_label_without_class():
     assert len(actor1.shared_locations(actor=actor2)) == 1
     assert len(actor1.shared_locations(actor=actor2, location_labels=["Library"])) == 1
 
+
 def test_location_label_with_class():
     env = p2n.Environment()
     actor1 = p2n.Actor()


### PR DESCRIPTION
This PR adds the possibility to set a location label in env.connect_actors() and actor.connect(). With this change, users can quickly connect actors using a labeled location without needing to define a dedicated location class solely for that purpose.